### PR TITLE
Added Relative Python Environment Path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from src import *
 
 


### PR DESCRIPTION
It's so you can not only use main.py as an executable within GNU/Linux as ./main.py, but you can run it in a virtualenv so you don't clobber your system with sudo pip